### PR TITLE
Fix symbol-summary unresolved callable parameter evidence

### DIFF
--- a/crates/browse/src/symbol_summary.rs
+++ b/crates/browse/src/symbol_summary.rs
@@ -11,8 +11,8 @@ use crate::common::format_span;
 use crate::edges::edge_record_from_graph_nodes;
 use crate::refs::read_snippet;
 use bonsai_callgraph::{CallEdge, ResolvedCallGraph};
-use bonsai_common::{FuncId, SymbolId};
-use bonsai_lang_api::DeclKind;
+use bonsai_common::{FuncId, Span, SymbolId};
+use bonsai_lang_api::{for_each_flow_event, DeclKind, FlowEvent};
 use bonsai_workspace::Workspace;
 use serde::Serialize;
 
@@ -55,8 +55,9 @@ pub struct SymbolImport {
     pub line: u32,
 }
 
-/// A call expression for which workspace candidates existed but the resolver
-/// could not prove a unique/narrowed runtime target.
+/// A call expression for which the resolver could not prove a runtime target.
+/// This includes ambiguous workspace candidates and callable-parameter
+/// invocations without a compiler-proven binding.
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct UnresolvedCallEvidence {
     pub evidence_kind: SymbolEvidenceKind,
@@ -154,10 +155,27 @@ fn symbol_summary(
     sort_edges(&mut direct_callers);
     sort_edges(&mut direct_callees);
 
-    let mut unresolved_calls = graph
+    let unresolved_workspace_spans = graph
         .unresolved_workspace_call_sites()
         .filter(|(caller, _)| *caller == func)
-        .map(|(_, span)| {
+        .map(|(_, span)| span)
+        .collect::<Vec<_>>();
+    let semantic_outgoing_spans = graph
+        .callees_of(func)
+        .filter(|edge| edge.precision.is_semantic())
+        .map(|edge| edge.span)
+        .collect::<Vec<_>>();
+    let unresolved_parameter_spans = unresolved_callable_parameter_spans(
+        &decl.flow_events,
+        &decl.params,
+        &semantic_outgoing_spans,
+        &unresolved_workspace_spans,
+    );
+
+    let mut unresolved_calls = unresolved_workspace_spans
+        .iter()
+        .copied()
+        .map(|span| {
             let (file, line, column) = format_span(&span, ws);
             UnresolvedCallEvidence {
                 evidence_kind: SymbolEvidenceKind::Unresolved,
@@ -170,11 +188,24 @@ fn symbol_summary(
             }
         })
         .collect::<Vec<_>>();
+    unresolved_calls.extend(unresolved_parameter_spans.iter().map(|span| {
+        let (file, line, column) = format_span(span, ws);
+        UnresolvedCallEvidence {
+            evidence_kind: SymbolEvidenceKind::Unresolved,
+            file,
+            line,
+            column,
+            call_text: read_snippet(ws, span),
+            reason: "callable parameter invocation has no compiler-proven binding".to_string(),
+        }
+    }));
     unresolved_calls.sort_by(|left, right| {
         left.file
             .cmp(&right.file)
             .then_with(|| left.line.cmp(&right.line))
             .then_with(|| left.column.cmp(&right.column))
+            .then_with(|| left.call_text.cmp(&right.call_text))
+            .then_with(|| left.reason.cmp(&right.reason))
     });
 
     let mut imports = ws
@@ -201,10 +232,16 @@ fn symbol_summary(
     });
 
     let mut analysis_incomplete_reasons = Vec::new();
-    if !unresolved_calls.is_empty() {
+    if !unresolved_workspace_spans.is_empty() {
         analysis_incomplete_reasons.push(format!(
             "{} workspace call site(s) have candidates but no compiler-proven target",
-            unresolved_calls.len()
+            unresolved_workspace_spans.len()
+        ));
+    }
+    if !unresolved_parameter_spans.is_empty() {
+        analysis_incomplete_reasons.push(format!(
+            "{} callable parameter invocation(s) have no compiler-proven binding",
+            unresolved_parameter_spans.len()
         ));
     }
     Some(SymbolSummary {
@@ -237,6 +274,31 @@ fn symbol_summary(
         analysis_complete: analysis_incomplete_reasons.is_empty(),
         analysis_incomplete_reasons,
     })
+}
+
+/// Collect direct calls through parameters that the context-free callgraph
+/// cannot prove. This stays declaration-local: callers may bind a parameter
+/// at runtime, but that does not justify a resolved summary edge here.
+fn unresolved_callable_parameter_spans(
+    events: &[FlowEvent],
+    params: &[String],
+    semantic_outgoing_spans: &[Span],
+    unresolved_workspace_spans: &[Span],
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+    for_each_flow_event(events, &mut |event| {
+        if let FlowEvent::Call { span, name, .. } = event {
+            if params.iter().any(|param| param == name.trim())
+                && !semantic_outgoing_spans.contains(span)
+                && !unresolved_workspace_spans.contains(span)
+            {
+                spans.push(*span);
+            }
+        }
+    });
+    spans.sort_unstable_by_key(|span| (span.file.raw(), span.start, span.end));
+    spans.dedup();
+    spans
 }
 
 fn summary_edge(ws: &Workspace, graph: &ResolvedCallGraph, edge: &CallEdge) -> Option<SymbolCallEdge> {

--- a/crates/cli/tests/browse_commands.rs
+++ b/crates/cli/tests/browse_commands.rs
@@ -2110,6 +2110,88 @@ fn symbol_summary_includes_source_and_parameters() {
 }
 
 #[test]
+fn symbol_summary_preserves_unresolved_callable_parameter_without_resolving_default() {
+    let tmp = tempdir_for_test("bonsai_symbol_summary_callable_parameter");
+    std::fs::write(
+        tmp.join("app.py"),
+        r#"
+from typing import Any, Callable
+
+def apply_authorized_patch(value: str) -> dict[str, Any]:
+    return {"value": value}
+
+def wrapper(
+    value: str,
+    apply_engine: Callable[..., dict[str, Any]] = apply_authorized_patch,
+) -> dict[str, Any]:
+    return apply_engine(value)
+"#,
+    )
+    .expect("write callable-parameter fixture");
+
+    let Some(trace) = run(&["trace", tmp.to_str().unwrap(), "wrapper", "--format", "json"]) else {
+        return;
+    };
+    let trace: serde_json::Value = serde_json::from_str(&trace).expect("trace JSON");
+    assert!(
+        trace["summary"]["analysis_incomplete_reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons
+                .iter()
+                .any(|reason| reason.as_str() == Some("unresolved-call:apply_engine"))),
+        "trace must retain the unresolved callable-parameter invocation: {trace}"
+    );
+
+    let Some(out) = run(&[
+        "symbol-summary",
+        tmp.to_str().unwrap(),
+        "--symbol",
+        "wrapper",
+        "--format",
+        "json",
+        "--all",
+    ]) else {
+        return;
+    };
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&out).expect("summary JSON");
+    let row = rows.first().expect("wrapper summary");
+    assert_eq!(row["graph_scope"], "direct_resolved_neighbors");
+    assert_eq!(row["analysis_complete"], false);
+    assert!(
+        row["analysis_incomplete_reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons.iter().any(|reason| {
+                reason
+                    .as_str()
+                    .is_some_and(|reason| reason.contains("callable parameter invocation"))
+            })),
+        "symbol-summary must explain the unresolved callable-parameter invocation: {out}"
+    );
+    assert!(
+        row["source"].as_str().is_some_and(
+            |source| source.contains("apply_engine") && source.contains("apply_authorized_patch")
+        ),
+        "summary source must retain the callable default expression: {out}"
+    );
+    assert!(
+        row["direct_callees"].as_array().is_some_and(|callees| callees
+            .iter()
+            .all(|callee| callee["callee"] != "apply_authorized_patch")),
+        "a parameter default must not become a resolved direct callee: {out}"
+    );
+    assert!(
+        row["unresolved_calls"]
+            .as_array()
+            .is_some_and(|calls| calls.iter().any(|call| call["call_text"]
+                .as_str()
+                .is_some_and(|text| text.contains("apply_engine")))),
+        "symbol-summary must preserve unresolved callable-parameter evidence: {out}"
+    );
+
+    let _ = std::fs::remove_dir_all(tmp);
+}
+
+#[test]
 fn inspect_from_to_markers_work_on_kotlin() {
     // Cross-class Kotlin flow: handleRequest → updateUser →
     // runAdminCommand → Runtime.getRuntime().exec. Filter markers


### PR DESCRIPTION
## Summary

Fix `symbol-summary` so calls through callable parameters are surfaced as
unresolved when Bonsai cannot prove their runtime binding.

Previously, `trace` correctly reported an unresolved call through a Python
callable parameter while `symbol-summary` reported no unresolved calls and
could therefore mark the summary complete.

This is intentionally a bounded `symbol-summary` change. It does not alter
resolver or callgraph semantics and does not infer a parameter's default
expression as its runtime target.

## Evidence

The issue is reproducible with:

```python
def wrapper(
    value: str,
    apply_engine: Callable[..., dict[str, Any]] = apply_authorized_patch,
) -> dict[str, Any]:
    return apply_engine(value)
```

Before this change:

- `trace` reported `unresolved-call:apply_engine`.
- `symbol-summary` returned an empty `unresolved_calls`.
- `symbol-summary` could report `analysis_complete: true`.
- The default expression `apply_authorized_patch` does not prove the runtime
  target because callers may override `apply_engine`.

Root cause:

`symbol-summary` only consumed
`ResolvedCallGraph::unresolved_workspace_call_sites()`. That represents the
narrower case where workspace candidates exist but the resolver cannot prove a
target.

For a callable parameter such as `apply_engine`, there can be zero workspace
declaration candidates, so the call is unresolved without appearing in that
list.

The fix adds declaration-local evidence using existing compiler facts:

- walk the selected declaration's `FlowEvent::Call` events with
  `for_each_flow_event`;
- select calls whose normalized name matches a declaration parameter;
- exclude sites with an existing semantic outgoing callgraph edge;
- exclude sites already represented by `unresolved_workspace_call_sites()`;
- report the remaining call as unresolved evidence.

The implementation remains language-neutral and does not add guessed graph
edges.

Negative case:

A default such as:

```python
apply_engine: Callable[...] = apply_authorized_patch
```

does **not** add `apply_authorized_patch` to `direct_callees`.

Added regression:

`symbol_summary_preserves_unresolved_callable_parameter_without_resolving_default`

It verifies that:

- `trace` retains `unresolved-call:apply_engine`;
- `symbol-summary` reports the invocation in `unresolved_calls`;
- `analysis_complete` becomes `false`;
- `analysis_incomplete_reasons` explains the callable-parameter gap;
- `apply_authorized_patch` is not fabricated as a resolved direct callee.

The original real-world reproduction was also retested against:

`Orchestrator.Orchestrator.orchestrator.authorized_draft_patch_apply.execute_authorized_draft_patch_apply`

The source contains:

```python
apply_engine: Callable[..., dict[str, Any]] = apply_authorized_patch
```

and later:

```python
engine_result = apply_engine(...)
```

After this change, `symbol-summary` reports the callable parameter invocation in
`unresolved_calls` with:

```text
callable parameter invocation has no compiler-proven binding
```

and reports:

```json
"analysis_complete": false
```

while `apply_authorized_patch` remains absent from `direct_callees`.

## Validation

- [x] I ran the smallest focused tests for this change.
- [x] I ran the applicable gates from [Release Readiness][release-readiness].
- [ ] I updated public documentation for CLI, SDK, rule-schema, output, cache,
      or behavior changes.
- [x] I followed all output pages/cursors before making a completeness claim.
- [x] I did not add semantic caps, guessed edges, private corpus knowledge, or
      security API inventories to shared analysis.
- [x] I did not commit credentials, private source, generated workspace caches,
      benchmark checkouts, or Cargo build artifacts.

Commands/results:

- `cargo +1.88 fmt --all -- --check` — passed
- `cargo +1.88 check --workspace --all-targets --locked` — passed
- `cargo +1.88 test --workspace` — passed
- `cargo +1.88 test -p bonsai-ninja --test browse_commands -- --test-threads=1`
  — 262 passed
- `cargo +1.88 test -p bonsai-ninja --test sdk_cli_parity`
  — 18 passed
- `cargo +1.88 test -p bonsai-ninja --test per_lang_cli_matrix`
  — 1029 passed
- `cargo +1.88 test --release -p bonsai-ninja-conformance --test architecture_invariants`
  — 81 passed
- `scripts/audit-hardcoded.sh --check`
  — 0 production violations

The original Orchestrator reproduction was also validated with the source-built
CLI.

An earlier parallel `browse_commands` run produced eight child-process
`SIGBUS` failures on this machine. One affected test passed in isolation and
the entire 262-test suite passed serially. A subsequent full
`cargo +1.88 test --workspace` run passed cleanly in parallel.

## Remaining limits

This change identifies unresolved calls where a declaration parameter is
invoked and no semantic callgraph edge proves the target.

It does not attempt runtime interprocedural binding inference for arbitrary
caller-supplied callable values, and it intentionally does not resolve a
parameter to its default expression.

The external Elasticsearch large-workspace release gate was not run for this
focused change.

[release-readiness]: https://github.com/gromhacks/bonsai-ninja/blob/main/docs/RELEASE_READINESS.md